### PR TITLE
feat: 增加睡眠互动模式、自定义机器人称呼及优化唤醒防刷屏逻辑

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - 支持自定义指令，可在配置面板修改
 - 定时闭嘴
 - 修改群昵称显示闭嘴状态
+- 支持睡眠模式互动，在定时闭嘴期间支持沉浸式哄睡与叫醒体验
 
 ## 使用方法
 
@@ -31,6 +32,8 @@
 - `require_prefix`：是否启用前缀模式，默认`启用`
 - `scheduled_shutup_enabled`：是否启用定时闭嘴，默认`关闭`
 - `scheduled_shutup_times`：定时闭嘴时间段
+- `bot_name`：机器人的自称（用于睡眠唤醒等提示语中），默认 `小爱`
+- `sleep_mode_enabled`：是否启用睡眠唤醒互动（开启后定时闭嘴期间会有相应的哄睡、叫醒等提示语），默认 `启用`
 - `group_card_update_enabled`：是否启用群昵称剩余时长显示
 - `group_card_template`：群昵称显示模板
 - `llm_tool_enabled`：是否启用 LLM 工具调用，默认`关闭`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - `scheduled_shutup_times`：定时闭嘴时间段
 - `bot_name`：机器人的自称（用于睡眠唤醒等提示语中），默认 `小爱`
 - `sleep_mode_enabled`：是否启用睡眠唤醒互动（开启后定时闭嘴期间会有相应的哄睡、叫醒等提示语），默认 `启用`
+- `temp_wake_duration`：睡眠模式下被临时叫醒后保持清醒的时长（秒），默认使用插件内置值，如需调整请在配置文件中显式设置
 - `group_card_update_enabled`：是否启用群昵称剩余时长显示
 - `group_card_template`：群昵称显示模板
 - `llm_tool_enabled`：是否启用 LLM 工具调用，默认`关闭`

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -49,7 +49,7 @@
 "bot_name": {
     "type": "string",
     "description": "机器人的自称",
-    "hint":"用于睡眠提示语。建议将此名字同步加入 AstrBot 平台设置中的‘唤醒词’，以实现直接喊名字唤醒的功能喵！",,
+    "hint":"用于睡眠提示语。建议将此名字同步加入 AstrBot 平台设置中的‘唤醒词’，以实现直接喊名字唤醒的功能喵！",
     "default": "小爱"
   },
   "sleep_mode_enabled": {
@@ -57,6 +57,12 @@
     "description": "启用睡眠唤醒互动",
     "hint": "开启后，定时闭嘴期间会有相应的哄睡、叫醒等互动提示语。若仅需要安静的定时禁言，请关闭此项",
     "default": true
+  },
+"temp_wake_duration": {
+    "type": "int",
+    "description": "临时唤醒保持时长(秒)",
+    "hint": "睡眠模式下，bot 被叫醒后保持清醒的状态时长，过期后将重新入睡。默认 300 秒 (5分钟)，推荐填写60的倍数，叫醒会显示'时间//60'分钟",
+    "default": 300
   },
   "scheduled_shutup_times": {
     "type": "text",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -3,13 +3,13 @@
     "type": "list",
     "description": "闭嘴指令列表",
     "items": { "type": "string" },
-    "default": ["闭嘴", "stop"]
+    "default": ["闭嘴", "stop","睡吧"]
   },
   "unshutup_commands": {
     "type": "list",
     "description": "解除闭嘴指令列表",
     "items": { "type": "string" },
-    "default": ["说话", "停止闭嘴"]
+    "default": ["说话", "停止闭嘴","醒醒"]
   },
   "default_duration": {
     "type": "int",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -49,7 +49,7 @@
 "bot_name": {
     "type": "string",
     "description": "机器人的自称",
-    "hint": "用于睡眠唤醒等提示语中的自称",
+    "hint":"用于睡眠提示语。建议将此名字同步加入 AstrBot 平台设置中的‘唤醒词’，以实现直接喊名字唤醒的功能喵！",,
     "default": "小爱"
   },
   "sleep_mode_enabled": {

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -46,6 +46,12 @@
     "hint": "开启后，bot 会在指定时间段内自动保持沉默",
     "default": false
   },
+"bot_name": {
+    "type": "string",
+    "description": "机器人的自称",
+    "hint": "用于睡眠唤醒等提示语中的自称",
+    "default": "小爱"
+  },
   "scheduled_shutup_times": {
     "type": "text",
     "description": "定时闭嘴时间段",

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -52,6 +52,12 @@
     "hint": "用于睡眠唤醒等提示语中的自称",
     "default": "小爱"
   },
+  "sleep_mode_enabled": {
+    "type": "bool",
+    "description": "启用睡眠唤醒互动",
+    "hint": "开启后，定时闭嘴期间会有相应的哄睡、叫醒等互动提示语。若仅需要安静的定时禁言，请关闭此项",
+    "default": true
+  },
   "scheduled_shutup_times": {
     "type": "text",
     "description": "定时闭嘴时间段",

--- a/main.py
+++ b/main.py
@@ -500,7 +500,7 @@ class ShutupPlugin(Star):
 
         # ====== 哄睡成功的专属回复 ======
         if is_sleep_early:
-            return f"那{self.bot_name}继续回被窝啦，晚安喵~"
+            return f"那{self.bot_name}继续回被窝啦，晚安~"
         # ====================================
 
         return self.shutup_reply.format(duration=duration, expiry_time=expiry_time)
@@ -535,7 +535,7 @@ class ShutupPlugin(Star):
                 self.temp_wake_map[origin] = time.time() + self.temp_wake_duration
                 wake_minutes = self.temp_wake_duration // 60
                 logger.info(f"[Shutup] ⏰ 睡眠期间被叫醒，清醒 {wake_minutes} 分钟")
-                return f"喵...谁呀...{self.bot_name}被叫醒了，还能强撑着陪你聊 {wake_minutes} 分钟哦..."
+                return f"谁呀...{self.bot_name}被叫醒了，还能强撑着陪你聊 {wake_minutes} 分钟哦..."
 
             logger.info(f"[Shutup] 🔊 已解除禁言 | 已禁言: {duration}s")
             # 睡眠模式下白天唤醒的回复

--- a/main.py
+++ b/main.py
@@ -36,7 +36,7 @@ class ShutupPlugin(Star):
         # 限制 default_duration 范围在 0-86400 秒(0-24小时)
         duration_config = config.get("default_duration", 600)
         if not isinstance(duration_config, (int, float)) or not (
-                0 <= duration_config <= 86400
+            0 <= duration_config <= 86400
         ):
             logger.warning(
                 f"[Shutup] ⚠️ default_duration 配置无效({duration_config})，使用默认值 600s"
@@ -74,9 +74,9 @@ class ShutupPlugin(Star):
         self.temp_wake_duration = config.get("temp_wake_duration", 300)  # 默认清醒 300秒 (5分钟)
         # 使用 pathlib 优化路径处理
         self.data_dir = (
-                Path(__file__).parent.parent.parent
-                / "plugin_data"
-                / "astrbot_plugin_shutup"
+            Path(__file__).parent.parent.parent
+            / "plugin_data"
+            / "astrbot_plugin_shutup"
         )
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.silence_map_path = self.data_dir / "silence_map.json"
@@ -214,7 +214,7 @@ class ShutupPlugin(Star):
         return str(sender_id) in [str(admin) for admin in admins]
 
     async def _update_group_card(
-            self, event: AstrMessageEvent, origin: str, remaining_minutes: int
+        self, event: AstrMessageEvent, origin: str, remaining_minutes: int
     ) -> None:
         """更新群昵称显示剩余时长"""
         if not self.group_card_enabled:
@@ -260,11 +260,11 @@ class ShutupPlugin(Star):
                     )
                     # 群昵称(群名片)
                     self.original_group_cards[origin] = (
-                            member_info.get("card", "") or ""
+                        member_info.get("card", "") or ""
                     )
                     # QQ昵称
                     self.original_nicknames[origin] = (
-                            member_info.get("nickname", "") or ""
+                        member_info.get("nickname", "") or ""
                     )
                     logger.debug(
                         f"[Shutup] 保存原始信息 | 群昵称: {self.original_group_cards[origin]} | QQ昵称: {self.original_nicknames[origin]}"
@@ -384,7 +384,7 @@ class ShutupPlugin(Star):
                 event.stop_event()
                 return
 
-        # 3. 检查定时闭嘴 (bot的睡眠时间)  <-- 注意这里，和上面的 if 是平级的喵！
+        # 3. 检查定时闭嘴 (bot的睡眠时间)
         if self._is_in_scheduled_time():
             if self.sleep_mode_enabled:
                 # 开启了睡眠模式：执行睡眠互动逻辑
@@ -457,7 +457,7 @@ class ShutupPlugin(Star):
                 return
 
     async def _handle_shutup_command(
-            self, event: AstrMessageEvent, text: str, origin: str
+        self, event: AstrMessageEvent, text: str, origin: str
     ) -> str:
         """处理闭嘴指令"""
         # ====== 判断是不是在半夜提前哄睡 ======
@@ -506,7 +506,7 @@ class ShutupPlugin(Star):
         return self.shutup_reply.format(duration=duration, expiry_time=expiry_time)
 
     async def _handle_unshutup_command(
-            self, event: AstrMessageEvent, origin: str
+        self, event: AstrMessageEvent, origin: str
     ) -> str:
         """处理解除闭嘴指令"""
         # 计算已禁言时长

--- a/main.py
+++ b/main.py
@@ -384,45 +384,45 @@ class ShutupPlugin(Star):
                 event.stop_event()
                 return
 
-            # 3. 检查定时闭嘴 (bot的睡眠时间)
-            if self._is_in_scheduled_time():
-                if self.sleep_mode_enabled:
-                    # 开启了睡眠模式：执行睡眠互动逻辑
-                    wake_expiry = self.temp_wake_map.get(origin)
-                    if wake_expiry and time.time() < wake_expiry:
-                        remaining = int(wake_expiry - time.time())
-                        logger.info(f"[Shutup] ⏰ bot正处于梦游清醒状态 | 剩余: {remaining}s")
-                    else:
-                        if wake_expiry:
-                            self.temp_wake_map.pop(origin, None)
-
-                        logger.info("[Shutup] ⏰ 定时闭嘴(睡眠)生效中，呼呼呼...")
-
-                        # 判断是否是在呼叫 bot
-                        is_talking_to_me = self._check_prefix(event)
-                        cmd_prefix = self.context.get_config().get("command_prefix", "/")
-                        if isinstance(cmd_prefix, list):
-                            if any(text.startswith(p) for p in cmd_prefix):
-                                is_talking_to_me = True
-                        elif isinstance(cmd_prefix, str) and text.startswith(cmd_prefix):
-                            is_talking_to_me = True
-
-                        if is_talking_to_me:
-                            wake_word = self.unshutup_cmds[0] if self.unshutup_cmds else f"{self.bot_name}醒醒"
-                            display_prefix = cmd_prefix[0] if isinstance(cmd_prefix, list) and cmd_prefix else (
-                                "" if isinstance(cmd_prefix, list) else cmd_prefix)
-                            yield event.plain_result(
-                                f"{self.bot_name}已经睡了，要叫醒{self.bot_name}吗~（回复：{display_prefix}{wake_word}）")
-
-                        event.should_call_llm(False)
-                        event.stop_event()
-                        return
+        # 3. 检查定时闭嘴 (bot的睡眠时间)  <-- 注意这里，和上面的 if 是平级的喵！
+        if self._is_in_scheduled_time():
+            if self.sleep_mode_enabled:
+                # 开启了睡眠模式：执行睡眠互动逻辑
+                wake_expiry = self.temp_wake_map.get(origin)
+                if wake_expiry and time.time() < wake_expiry:
+                    remaining = int(wake_expiry - time.time())
+                    logger.info(f"[Shutup] ⏰ bot正处于梦游清醒状态 | 剩余: {remaining}s")
                 else:
-                    # 没开启睡眠模式：直接安静拦截，不回复任何话
-                    logger.info("[Shutup] ⏰ 定时闭嘴生效中")
+                    if wake_expiry:
+                        self.temp_wake_map.pop(origin, None)
+
+                    logger.info("[Shutup] ⏰ 定时闭嘴(睡眠)生效中，呼呼呼...")
+
+                    # 判断是否是在呼叫 bot
+                    is_talking_to_me = self._check_prefix(event)
+                    cmd_prefix = self.context.get_config().get("command_prefix", "/")
+                    if isinstance(cmd_prefix, list):
+                        if any(text.startswith(p) for p in cmd_prefix):
+                            is_talking_to_me = True
+                    elif isinstance(cmd_prefix, str) and text.startswith(cmd_prefix):
+                        is_talking_to_me = True
+
+                    if is_talking_to_me:
+                        wake_word = self.unshutup_cmds[0] if self.unshutup_cmds else f"{self.bot_name}醒醒"
+                        display_prefix = cmd_prefix[0] if isinstance(cmd_prefix, list) and cmd_prefix else (
+                            "" if isinstance(cmd_prefix, list) else cmd_prefix)
+                        yield event.plain_result(
+                            f"{self.bot_name}已经睡了，要叫醒{self.bot_name}吗~（回复：{display_prefix}{wake_word}）")
+
                     event.should_call_llm(False)
                     event.stop_event()
                     return
+            else:
+                # 没开启睡眠模式：直接安静拦截，不回复任何话
+                logger.info("[Shutup] ⏰ 定时闭嘴生效中")
+                event.should_call_llm(False)
+                event.stop_event()
+                return
 
         # 4. 检查手动禁言状态
         expiry = self.silence_map.get(origin)

--- a/main.py
+++ b/main.py
@@ -69,9 +69,9 @@ class ShutupPlugin(Star):
         self.silence_map = {}
         # ====== 新增：睡眠唤醒配置 ======
         self.bot_name = config.get("bot_name", "小爱")  # 默认叫小爱，可以在配置面板改喵
+        self.sleep_mode_enabled = config.get("sleep_mode_enabled", True)  # 新增：睡眠模式开关
         self.temp_wake_map = {}  # 记录谁把bot叫醒了
         self.temp_wake_duration = config.get("temp_wake_duration", 300)  # 默认清醒 300秒 (5分钟)
-        # ==================================
         # 使用 pathlib 优化路径处理
         self.data_dir = (
                 Path(__file__).parent.parent.parent
@@ -384,46 +384,45 @@ class ShutupPlugin(Star):
                 event.stop_event()
                 return
 
-        # 3. 检查定时闭嘴 (bot的睡眠时间)
-        if self._is_in_scheduled_time():
-            wake_expiry = self.temp_wake_map.get(origin)
-            if wake_expiry and time.time() < wake_expiry:
-                remaining = int(wake_expiry - time.time())
-                logger.info(f"[Shutup] ⏰ bot正处于梦游清醒状态 | 剩余: {remaining}s")
-            else:
-                if wake_expiry:
-                    self.temp_wake_map.pop(origin, None)
+            # 3. 检查定时闭嘴 (bot的睡眠时间)
+            if self._is_in_scheduled_time():
+                if self.sleep_mode_enabled:
+                    # 开启了睡眠模式：执行睡眠互动逻辑
+                    wake_expiry = self.temp_wake_map.get(origin)
+                    if wake_expiry and time.time() < wake_expiry:
+                        remaining = int(wake_expiry - time.time())
+                        logger.info(f"[Shutup] ⏰ bot正处于梦游清醒状态 | 剩余: {remaining}s")
+                    else:
+                        if wake_expiry:
+                            self.temp_wake_map.pop(origin, None)
 
-                logger.info("[Shutup] ⏰ 定时闭嘴(睡眠)生效中，呼呼呼...")
+                        logger.info("[Shutup] ⏰ 定时闭嘴(睡眠)生效中，呼呼呼...")
 
-                # ====== 梦中被戳到的专属回复 ======
-                # 判断用户是不是在明确找bot（比如 @了bot，或者带了前缀）
-                is_talking_to_me = self._check_prefix(event)
+                        # 判断是否是在呼叫 bot
+                        is_talking_to_me = self._check_prefix(event)
+                        cmd_prefix = self.context.get_config().get("command_prefix", "/")
+                        if isinstance(cmd_prefix, list):
+                            if any(text.startswith(p) for p in cmd_prefix):
+                                is_talking_to_me = True
+                        elif isinstance(cmd_prefix, str) and text.startswith(cmd_prefix):
+                            is_talking_to_me = True
 
-                # 或者带了全局命令符（比如 /）
-                cmd_prefix = self.context.get_config().get("command_prefix", "/")
-                if isinstance(cmd_prefix, list):
-                    if any(text.startswith(p) for p in cmd_prefix):
-                        is_talking_to_me = True
-                elif isinstance(cmd_prefix, str) and text.startswith(cmd_prefix):
-                    is_talking_to_me = True
+                        if is_talking_to_me:
+                            wake_word = self.unshutup_cmds[0] if self.unshutup_cmds else f"{self.bot_name}醒醒"
+                            display_prefix = cmd_prefix[0] if isinstance(cmd_prefix, list) and cmd_prefix else (
+                                "" if isinstance(cmd_prefix, list) else cmd_prefix)
+                            yield event.plain_result(
+                                f"{self.bot_name}已经睡了，要叫醒{self.bot_name}吗~（回复：{display_prefix}{wake_word}）")
 
-                # 如果你明确跟bot搭话，bot就会迷迷糊糊地抗议
-                if is_talking_to_me:
-                    # 动态获取你在后台设置的第一个唤醒词，比如 "小爱醒醒"
-                    wake_word = self.unshutup_cmds[0] if self.unshutup_cmds else "小爱醒醒"
-
-                    # 获取当前的命令符号用于显示
-                    display_prefix = cmd_prefix[0] if isinstance(cmd_prefix, list) and cmd_prefix else (
-                        "" if isinstance(cmd_prefix, list) else cmd_prefix)
-
-                    yield event.plain_result(
-                        f"{self.bot_name}已经睡了，要叫醒{self.bot_name}吗~（回复：{display_prefix}{wake_word}）")
-                # ==========================================
-
-                event.should_call_llm(False)
-                event.stop_event()
-                return
+                        event.should_call_llm(False)
+                        event.stop_event()
+                        return
+                else:
+                    # 没开启睡眠模式：直接安静拦截，不回复任何话
+                    logger.info("[Shutup] ⏰ 定时闭嘴生效中")
+                    event.should_call_llm(False)
+                    event.stop_event()
+                    return
 
         # 4. 检查手动禁言状态
         expiry = self.silence_map.get(origin)
@@ -447,7 +446,7 @@ class ShutupPlugin(Star):
     ) -> str:
         """处理闭嘴指令"""
         # ====== 判断是不是在半夜提前哄睡 ======
-        is_sleep_early = self._is_in_scheduled_time() and origin in getattr(self, 'temp_wake_map', {})
+        is_sleep_early = self.sleep_mode_enabled and self._is_in_scheduled_time() and origin in getattr(self,'temp_wake_map',{})
         if is_sleep_early:
             self.temp_wake_map.pop(origin, None)  # 清除清醒倒计时
         # ==========================================
@@ -516,15 +515,20 @@ class ShutupPlugin(Star):
 
         expiry_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time()))
         # ====== 新增：处理睡眠期间被强行叫醒 ======
-        if self._is_in_scheduled_time():
-            self.temp_wake_map[origin] = time.time() + self.temp_wake_duration
-            wake_minutes = self.temp_wake_duration // 60
-            logger.info(f"[Shutup] ⏰ 睡眠期间被叫醒，清醒 {wake_minutes} 分钟")
-            return f"喵...谁呀...{self.bot_name}被叫醒了，还能强撑着陪你聊 {wake_minutes} 分钟哦..."
+        if self.sleep_mode_enabled:
+            if self._is_in_scheduled_time():
+                self.temp_wake_map[origin] = time.time() + self.temp_wake_duration
+                wake_minutes = self.temp_wake_duration // 60
+                logger.info(f"[Shutup] ⏰ 睡眠期间被叫醒，清醒 {wake_minutes} 分钟")
+                return f"喵...谁呀...{self.bot_name}被叫醒了，还能强撑着陪你聊 {wake_minutes} 分钟哦..."
 
+            logger.info(f"[Shutup] 🔊 已解除禁言 | 已禁言: {duration}s")
+            # 睡眠模式下白天唤醒的回复
+            return f"{self.bot_name}早就醒着啦喵！随时可以陪你聊天哦~"
+
+        # ====== 如果没开睡眠模式，就用原作者设定的默认解除文本 ======
         logger.info(f"[Shutup] 🔊 已解除禁言 | 已禁言: {duration}s")
-        # 正常白天唤醒的回复
-        return f"{self.bot_name}早就醒着啦喵！随时可以陪你聊天哦~"
+        return self.unshutup_reply.format(duration=duration, expiry_time=expiry_time)
 
     @filter.llm_tool(name="shutup")
     async def llm_shutup(self, event: AstrMessageEvent, duration: int, unit: str = "m"):

--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import asyncio
 from datetime import datetime
 from pathlib import Path
 
+
 class ShutupPlugin(Star):
     # 时间单位转换(秒)
     TIME_UNITS = {"s": 1, "m": 60, "h": 3600, "d": 86400}
@@ -35,7 +36,7 @@ class ShutupPlugin(Star):
         # 限制 default_duration 范围在 0-86400 秒(0-24小时)
         duration_config = config.get("default_duration", 600)
         if not isinstance(duration_config, (int, float)) or not (
-            0 <= duration_config <= 86400
+                0 <= duration_config <= 86400
         ):
             logger.warning(
                 f"[Shutup] ⚠️ default_duration 配置无效({duration_config})，使用默认值 600s"
@@ -66,11 +67,16 @@ class ShutupPlugin(Star):
         self.scheduled_time_ranges = self._parse_time_ranges(self.scheduled_times_text)
 
         self.silence_map = {}
+        # ====== 新增：睡眠唤醒配置 ======
+        self.bot_name = config.get("bot_name", "小爱")  # 默认叫小爱，可以在配置面板改喵
+        self.temp_wake_map = {}  # 记录谁把bot叫醒了
+        self.temp_wake_duration = config.get("temp_wake_duration", 300)  # 默认清醒 300秒 (5分钟)
+        # ==================================
         # 使用 pathlib 优化路径处理
         self.data_dir = (
-            Path(__file__).parent.parent.parent
-            / "plugin_data"
-            / "astrbot_plugin_shutup"
+                Path(__file__).parent.parent.parent
+                / "plugin_data"
+                / "astrbot_plugin_shutup"
         )
         self.data_dir.mkdir(parents=True, exist_ok=True)
         self.silence_map_path = self.data_dir / "silence_map.json"
@@ -196,23 +202,19 @@ class ShutupPlugin(Star):
             return False
 
     def _check_admin(self, event: AstrMessageEvent) -> bool:
-        """检查用户是否是管理员
-
-        Returns:
-            bool: True 表示是管理员(或不需要管理员权限)，False 表示不是管理员
-        """
         if not self.require_admin:
             return True
 
+        # 修正键名为 admins_id
         # 获取管理员列表
-        admins = self.context.get_config().get("admins", [])
+        admins = self.context.get_config().get("admins_id", [])
         sender_id = event.get_sender_id()
 
         # 检查发送者是否在管理员列表中
         return str(sender_id) in [str(admin) for admin in admins]
 
     async def _update_group_card(
-        self, event: AstrMessageEvent, origin: str, remaining_minutes: int
+            self, event: AstrMessageEvent, origin: str, remaining_minutes: int
     ) -> None:
         """更新群昵称显示剩余时长"""
         if not self.group_card_enabled:
@@ -258,11 +260,11 @@ class ShutupPlugin(Star):
                     )
                     # 群昵称(群名片)
                     self.original_group_cards[origin] = (
-                        member_info.get("card", "") or ""
+                            member_info.get("card", "") or ""
                     )
                     # QQ昵称
                     self.original_nicknames[origin] = (
-                        member_info.get("nickname", "") or ""
+                            member_info.get("nickname", "") or ""
                     )
                     logger.debug(
                         f"[Shutup] 保存原始信息 | 群昵称: {self.original_group_cards[origin]} | QQ昵称: {self.original_nicknames[origin]}"
@@ -382,12 +384,46 @@ class ShutupPlugin(Star):
                 event.stop_event()
                 return
 
-        # 3. 检查定时闭嘴
+        # 3. 检查定时闭嘴 (bot的睡眠时间)
         if self._is_in_scheduled_time():
-            logger.info("[Shutup] ⏰ 定时闭嘴生效中")
-            event.should_call_llm(False)
-            event.stop_event()
-            return
+            wake_expiry = self.temp_wake_map.get(origin)
+            if wake_expiry and time.time() < wake_expiry:
+                remaining = int(wake_expiry - time.time())
+                logger.info(f"[Shutup] ⏰ bot正处于梦游清醒状态 | 剩余: {remaining}s")
+            else:
+                if wake_expiry:
+                    self.temp_wake_map.pop(origin, None)
+
+                logger.info("[Shutup] ⏰ 定时闭嘴(睡眠)生效中，呼呼呼...")
+
+                # ====== 梦中被戳到的专属回复 ======
+                # 判断用户是不是在明确找bot（比如 @了bot，或者带了前缀）
+                is_talking_to_me = self._check_prefix(event)
+
+                # 或者带了全局命令符（比如 /）
+                cmd_prefix = self.context.get_config().get("command_prefix", "/")
+                if isinstance(cmd_prefix, list):
+                    if any(text.startswith(p) for p in cmd_prefix):
+                        is_talking_to_me = True
+                elif isinstance(cmd_prefix, str) and text.startswith(cmd_prefix):
+                    is_talking_to_me = True
+
+                # 如果你明确跟bot搭话，bot就会迷迷糊糊地抗议
+                if is_talking_to_me:
+                    # 动态获取你在后台设置的第一个唤醒词，比如 "小爱醒醒"
+                    wake_word = self.unshutup_cmds[0] if self.unshutup_cmds else "小爱醒醒"
+
+                    # 获取当前的命令符号用于显示
+                    display_prefix = cmd_prefix[0] if isinstance(cmd_prefix, list) and cmd_prefix else (
+                        "" if isinstance(cmd_prefix, list) else cmd_prefix)
+
+                    yield event.plain_result(
+                        f"{self.bot_name}已经睡了，要叫醒{self.bot_name}吗~（回复：{display_prefix}{wake_word}）")
+                # ==========================================
+
+                event.should_call_llm(False)
+                event.stop_event()
+                return
 
         # 4. 检查手动禁言状态
         expiry = self.silence_map.get(origin)
@@ -407,9 +443,15 @@ class ShutupPlugin(Star):
                 return
 
     async def _handle_shutup_command(
-        self, event: AstrMessageEvent, text: str, origin: str
+            self, event: AstrMessageEvent, text: str, origin: str
     ) -> str:
         """处理闭嘴指令"""
+        # ====== 判断是不是在半夜提前哄睡 ======
+        is_sleep_early = self._is_in_scheduled_time() and origin in getattr(self, 'temp_wake_map', {})
+        if is_sleep_early:
+            self.temp_wake_map.pop(origin, None)  # 清除清醒倒计时
+        # ==========================================
+
         # 解析时长
         for cmd in self.shutup_cmds:
             if text.startswith(cmd):
@@ -442,10 +484,15 @@ class ShutupPlugin(Star):
         )
         logger.info(f"[Shutup] 🔇 已禁言 | 时长: {duration}s | 到期: {expiry_time}")
 
+        # ====== 哄睡成功的专属回复 ======
+        if is_sleep_early:
+            return f"那{self.bot_name}继续回被窝啦，晚安喵~"
+        # ====================================
+
         return self.shutup_reply.format(duration=duration, expiry_time=expiry_time)
 
     async def _handle_unshutup_command(
-        self, event: AstrMessageEvent, origin: str
+            self, event: AstrMessageEvent, origin: str
     ) -> str:
         """处理解除闭嘴指令"""
         # 计算已禁言时长
@@ -468,9 +515,16 @@ class ShutupPlugin(Star):
             self.origin_to_event_map.pop(origin, None)
 
         expiry_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time()))
-        logger.info(f"[Shutup] 🔊 已解除禁言 | 已禁言: {duration}s")
+        # ====== 新增：处理睡眠期间被强行叫醒 ======
+        if self._is_in_scheduled_time():
+            self.temp_wake_map[origin] = time.time() + self.temp_wake_duration
+            wake_minutes = self.temp_wake_duration // 60
+            logger.info(f"[Shutup] ⏰ 睡眠期间被叫醒，清醒 {wake_minutes} 分钟")
+            return f"喵...谁呀...{self.bot_name}被叫醒了，还能强撑着陪你聊 {wake_minutes} 分钟哦..."
 
-        return self.unshutup_reply.format(duration=duration, expiry_time=expiry_time)
+        logger.info(f"[Shutup] 🔊 已解除禁言 | 已禁言: {duration}s")
+        # 正常白天唤醒的回复
+        return f"{self.bot_name}早就醒着啦喵！随时可以陪你聊天哦~"
 
     @filter.llm_tool(name="shutup")
     async def llm_shutup(self, event: AstrMessageEvent, duration: int, unit: str = "m"):
@@ -518,7 +572,7 @@ class ShutupPlugin(Star):
             f"[Shutup] 🔇 LLM 调用闭嘴 | 时长: {duration_seconds}s | 到期: {expiry_time}"
         )
 
-        return f"已设置闭嘴 {int(duration_seconds/60)} 分钟，到期时间: {expiry_time}"
+        return f"已设置闭嘴 {int(duration_seconds / 60)} 分钟，到期时间: {expiry_time}"
 
     async def terminate(self):
         # 停止群昵称更新任务

--- a/main.py
+++ b/main.py
@@ -537,6 +537,10 @@ class ShutupPlugin(Star):
         self.silence_map.pop(origin, None)
         self._save_silence_map()
 
+        now = time.time()
+        # 增加状态检查：判断当前是否已处于临时的“梦游清醒”状态
+        is_already_awake = origin in self.temp_wake_map and now < self.temp_wake_map[origin]
+
         # 恢复原始群昵称(如果启用)
         if self.group_card_enabled:
             await self._update_group_card(event, origin, 0)
@@ -545,17 +549,24 @@ class ShutupPlugin(Star):
             self.origin_to_event_map.pop(origin, None)
 
         expiry_time = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(time.time()))
-        # ====== 新增：处理睡眠期间被强行叫醒 ======
+        # ====== 处理睡眠期间被强行叫醒 ======
         if self.sleep_mode_enabled:
             if self._is_in_scheduled_time():
-                self.temp_wake_map[origin] = time.time() + self.temp_wake_duration
+                # 更新或刷新清醒到期时间
+                self.temp_wake_map[origin] = now + self.temp_wake_duration
                 wake_minutes = self.temp_wake_duration // 60
+
+                # 如果已经是清醒状态，则返回简洁的确认信息，避免重复播放较长的“被叫醒”台词
+                if is_already_awake:
+                    return f"{self.bot_name} 已经醒啦，会再陪你聊 {wake_minutes} 分钟哦~"
+
+                # 第一次被叫醒时的完整回复
                 logger.info(f"[Shutup] ⏰ 睡眠期间被叫醒，清醒 {wake_minutes} 分钟")
                 return f"谁呀...{self.bot_name}被叫醒了，还能强撑着陪你聊 {wake_minutes} 分钟哦..."
 
+            # 正常解除禁言日志
             logger.info(f"[Shutup] 🔊 已解除禁言 | 已禁言: {duration}s")
-            # 睡眠模式下白天唤醒的回复
-            return f"{self.bot_name}早就醒着啦喵！随时可以陪你聊天哦~"
+            return f"{self.bot_name}早就醒着啦！随时可以陪你聊天哦~"
 
         # ====== 如果没开睡眠模式，就用原作者设定的默认解除文本 ======
         logger.info(f"[Shutup] 🔊 已解除禁言 | 已禁言: {duration}s")

--- a/main.py
+++ b/main.py
@@ -71,7 +71,23 @@ class ShutupPlugin(Star):
         self.bot_name = config.get("bot_name", "小爱")  # 默认叫小爱，可以在配置面板改喵
         self.sleep_mode_enabled = config.get("sleep_mode_enabled", True)  # 新增：睡眠模式开关
         self.temp_wake_map = {}  # 记录谁把bot叫醒了
-        self.temp_wake_duration = config.get("temp_wake_duration", 300)  # 默认清醒 300秒 (5分钟)
+        # 睡眠唤醒持续时间（秒），确保为非负整数
+        raw_temp_wake_duration = config.get("temp_wake_duration", 300)
+        try:
+            temp_wake_duration = int(raw_temp_wake_duration)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"[ShutupPlugin] Invalid temp_wake_duration={raw_temp_wake_duration!r}, "
+                "falling back to default 300s."
+            )
+            temp_wake_duration = 300
+        if temp_wake_duration < 0:
+            logger.warning(
+                f"[ShutupPlugin] temp_wake_duration is negative ({temp_wake_duration}), "
+                "clamping to 0."
+            )
+            temp_wake_duration = 0
+        self.temp_wake_duration = temp_wake_duration  # 默认清醒 300秒 (5分钟)
         # 使用 pathlib 优化路径处理
         self.data_dir = (
             Path(__file__).parent.parent.parent

--- a/main.py
+++ b/main.py
@@ -398,19 +398,34 @@ class ShutupPlugin(Star):
 
                     logger.info("[Shutup] ⏰ 定时闭嘴(睡眠)生效中，呼呼呼...")
 
-                    # 判断是否是在呼叫 bot
-                    is_talking_to_me = self._check_prefix(event)
-                    cmd_prefix = self.context.get_config().get("command_prefix", "/")
-                    if isinstance(cmd_prefix, list):
-                        if any(text.startswith(p) for p in cmd_prefix):
+                    # ====== 严格判断是否在明确呼叫 bot（防刷屏） ======
+                    is_talking_to_me = False
+                    chain = event.get_messages()
+                    if chain:
+                        first_seg = chain[0]
+                        # 1. 检查是否明确 @ 了 bot
+                        if isinstance(first_seg, Comp.At) and str(first_seg.qq) == str(event.get_self_id()):
                             is_talking_to_me = True
-                    elif isinstance(cmd_prefix, str) and text.startswith(cmd_prefix):
+                        # 2. 检查是否使用了设定的唤醒前缀 (wake_prefix)
+                        elif isinstance(first_seg, Comp.Plain) and self.wake_prefix:
+                            if any(first_seg.text.startswith(p) for p in self.wake_prefix):
+                                is_talking_to_me = True
+
+                    # 3. 检查是否带有全局命令符 (如 /)
+                    cmd_prefix = self.context.get_config().get("command_prefix", "/")
+                    prefixes = cmd_prefix if isinstance(cmd_prefix, list) else [cmd_prefix]
+                    if any(text.startswith(p) for p in prefixes if p):  # 确保前缀不为空
                         is_talking_to_me = True
 
                     if is_talking_to_me:
                         wake_word = self.unshutup_cmds[0] if self.unshutup_cmds else f"{self.bot_name}醒醒"
-                        display_prefix = cmd_prefix[0] if isinstance(cmd_prefix, list) and cmd_prefix else (
-                            "" if isinstance(cmd_prefix, list) else cmd_prefix)
+
+                        # 如果需要前缀才加上，不需要的话就直接显示命令文本
+                        display_prefix = ""
+                        if self.require_prefix:
+                            display_prefix = cmd_prefix[0] if isinstance(cmd_prefix, list) and cmd_prefix else (
+                                "" if isinstance(cmd_prefix, list) else cmd_prefix)
+
                         yield event.plain_result(
                             f"{self.bot_name}已经睡了，要叫醒{self.bot_name}吗~（回复：{display_prefix}{wake_word}）")
 


### PR DESCRIPTION
✨ 新增功能 (Features)

自定义机器人称呼：在 _conf_schema.json 中新增了 bot_name 配置项。现在用户可以自定义机器人在互动提示语中的自称（默认为“小爱”），使交互更具个性化。

可选的睡眠互动模式：新增了 sleep_mode_enabled 开关（默认为开启）。开启后，在定时闭嘴期间被特定命令叫醒或哄睡时，bot 会有相应的沉浸式角色扮演回复（如“xx已经睡了”等）。若用户仅需要纯粹的静默定时禁言，关闭此项即可向下兼容原有的定时闭嘴逻辑。
为了获得更好的睡眠模式体验，建议在 AstrBot 的全局设置中将 bot_name（如“小维”）加入 wake_prefix 列表。这样即便在睡眠期间，你直接喊“小维醒醒”也能触发温馨提示喵！
如果希望提示语显示“回复：/小爱醒醒”，可以在配置插件时，将“醒醒”或“{机器人名}醒醒”加入 unshutup_commands 列表的第一项。

🐛 逻辑优化与防爆破 (Refactor & Fixes)

重构睡眠期的唤醒判定逻辑：原逻辑中如果用户关闭了 require_prefix，群内任意发言都会被判定为呼叫 bot，存在半夜刷屏的风险。本次修改在睡眠模式下实施了严格判定，只有明确 @bot、带有 wake_prefix 或全局命令符时，才会触发唤醒互动。

📝 文档更新 (Docs)

同步更新了 README.md，补充了新增配置项的说明及功能介绍。