### PR TITLE
fix: _update_loop 中先恢复群昵称再清理 store，避免 original_card 丢失导致昵称卡死在带徽章状态

### DIFF
--- a/core/group_card.py
+++ b/core/group_card.py
@@ -81,14 +81,16 @@ class GroupCardUpdater:
                             )
                         continue
 
-                    if origin in self._plugin._store:
-                        self._plugin._store.remove(origin)
-                        changed = True
-
+                    # 先 update(0) 恢复昵称，此时 store 还有 original_card
                     if event is not None:
                         await self.update(event, origin, 0)
                     else:
                         self.origin_to_event_map.pop(origin, None)
+
+                    # 昵称恢复完成后再清理 store
+                    if origin in self._plugin._store:
+                        self._plugin._store.remove(origin)
+                        changed = True
 
                 if changed:
                     self._plugin._store.save()


### PR DESCRIPTION
### 问题

闭嘴功能启用"群昵称显示模板"时，闭嘴结束后群昵称有时不能恢复到原始昵称，会一直卡在带徽章的状态（如`bot_name[闭嘴中 1 分钟]`）。此时若再次闭嘴，模板会在已卡住的昵称基础上再叠加新的徽章，导致昵称越来越长（如`bot_name[闭嘴中 1 分钟][闭嘴中 3 分钟]`）。

### 根因

`core/group_card.py` 的 `_update_loop()` 在检测到禁言过期时，执行顺序为：

1. `_store.remove(origin)` — 先删除持久化记录
2. `await self.update(event, origin, 0)` — 再恢复昵称

`update(0)` 内部调用 `_get_original_identity(origin)` 从 store 中获取原始群名片（`original_card`）。但此时 store 已被删除，取不到原始值，于是 fallback 到调用 QQ 接口 `get_group_member_info` 拉取当前群名片。此时群名片已被改为带徽章的版本（如上一次的`bot_name[闭嘴中 1 分钟]`），这个坏掉的值被当作"原始昵称"写回 store 并设置到群名片上，导致昵称无法真正恢复。

下次闭嘴再触发时，`{original_card}` 模板占位符被替换为这个坏掉的昵称，渲染出 `坏掉的昵称[闭嘴中 {remaining} 分钟]`，徽章不断累加。

### 修复

交换 `_update_loop` 中 `store.remove` 和 `update(0)` 的顺序：

1. 先调用 `await self.update(event, origin, 0)` 恢复昵称（此时 store 还在，`_get_original_identity` 能拿到正确的 `original_card`）
2. 再清理 store

对应的 `dispatch()` 路径（`core/handlers.py`）顺序本来就是对的（先 `update(0)` 再 `store.remove`），不受影响。

### 改动文件

- `core/group_card.py` — `_update_loop()` 中交换 `store.remove` 和 `update(0)` 的执行顺序